### PR TITLE
CDAP-15985 MixPanel Batch Source plugin - rename event_name to event.

### DIFF
--- a/src/main/java/io/cdap/plugin/mixpanel/source/batch/MixPanelSchemaHelper.java
+++ b/src/main/java/io/cdap/plugin/mixpanel/source/batch/MixPanelSchemaHelper.java
@@ -40,7 +40,7 @@ public class MixPanelSchemaHelper {
   }
 
   private static final Gson GSON = new GsonBuilder().create();
-  private static final String EVENT_NAME_FIELD = "event_name";
+  private static final String EVENT_NAME_FIELD = "event";
   private static final String EVENT_NAME_FIELD_DESC = "$event_name";
   private static final Schema MIX_PANEL_RECORD_SCHEMA = Schema.recordOf(
     "mixPanelRecord", Schema.Field.of("raw_event", Schema.of(Schema.Type.STRING)));
@@ -71,7 +71,7 @@ public class MixPanelSchemaHelper {
         .collect(Collectors.toSet());
 
       // make sure default fields available
-      fieldNames.add("event_name");
+      fieldNames.add(EVENT_NAME_FIELD);
       fieldNames.add("distinct_id");
       fieldNames.add("time");
 

--- a/src/test/java/io/cdap/plugin/mixpanel/source/batch/MixPanelSchemaHelperTest.java
+++ b/src/test/java/io/cdap/plugin/mixpanel/source/batch/MixPanelSchemaHelperTest.java
@@ -3,11 +3,14 @@ package io.cdap.plugin.mixpanel.source.batch;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.cdap.cdap.api.data.schema.Schema;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MixPanelSchemaHelperTest {
   @Rule
@@ -20,6 +23,33 @@ public class MixPanelSchemaHelperTest {
     Assert.assertEquals("_1_Starts_With_number", MixPanelSchemaHelper.escapeFieldName("1 Starts With number"));
     Assert.assertEquals("os", MixPanelSchemaHelper.escapeFieldName("$os"));
     Assert.assertEquals("mega_field", MixPanelSchemaHelper.escapeFieldName("$$$$$mega_field$$$$"));
+  }
+
+  @Test
+  public void testGetSchema() throws IOException {
+    WireMock.stubFor(
+      WireMock.post(WireMock.urlMatching("/api/2.0/events/properties/top/"))
+        .withBasicAuth("secret", "")
+        .withRequestBody(WireMock.containing("event1"))
+        .willReturn(WireMock.aResponse().withBody(TestHelper.getResource("describe conflicting 1.json"))
+        )
+    );
+
+    MixPanelBatchSourceConfig config = MixPanelBatchSourceConfig.builder()
+      .setMixPanelRestApiUrl(String.format("http://localhost:%d/", wireMockRule.port()))
+      .setApiSecret("secret")
+      .setSchemaByEvents("on")
+      .setEvents("event1")
+      .build();
+
+    Schema schema = MixPanelSchemaHelper.getSchemaFromConfig(config);
+    Set<String> schemaFields = schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toSet());
+    Assert.assertEquals(5, schemaFields.size());
+    Assert.assertTrue(schemaFields.contains("regular_field"));
+    Assert.assertTrue(schemaFields.contains("distinct_id"));
+    Assert.assertTrue(schemaFields.contains("time"));
+    Assert.assertTrue(schemaFields.contains("event"));
+    Assert.assertTrue(schemaFields.contains("conflict"));
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/mixpanel/source/batch/etl/MixPanelBatchSourceTest.java
+++ b/src/test/java/io/cdap/plugin/mixpanel/source/batch/etl/MixPanelBatchSourceTest.java
@@ -146,12 +146,12 @@ public class MixPanelBatchSourceTest extends HydratorTestBase {
 
     // ensure records in expected order
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager).stream()
-      .sorted(Comparator.comparing(structuredRecord -> structuredRecord.get("event_name")))
+      .sorted(Comparator.comparing(structuredRecord -> structuredRecord.get("event")))
       .collect(Collectors.toList());
 
     Assert.assertEquals(2, outputRecords.size());
-    Assert.assertEquals("Custom Event", outputRecords.get(0).get("event_name"));
-    Assert.assertEquals("Plan Upgraded", outputRecords.get(1).get("event_name"));
+    Assert.assertEquals("Custom Event", outputRecords.get(0).get("event"));
+    Assert.assertEquals("Plan Upgraded", outputRecords.get(1).get("event"));
     Assert.assertEquals("data 1 value", outputRecords.get(0).get("data_1"));
     Assert.assertNull(outputRecords.get(1).get("data_1"));
     Assert.assertNull(outputRecords.get(0).get("New_Plan"));


### PR DESCRIPTION
WIKI: https://wiki.cask.co/display/CE/Mixpanel+Batch+Source
JIRA: https://issues.cask.co/browse/CDAP-15985

This PR addresses renaming **event_name** field to **event** in schema.